### PR TITLE
AI Code Review Analytics: AI Prediction vs CI Reality

### DIFF
--- a/dashboards/Engineering/AI Metrics/AIReview.json
+++ b/dashboards/Engineering/AI Metrics/AIReview.json
@@ -80,7 +80,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -131,7 +133,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -182,7 +186,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -233,7 +239,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -330,7 +338,9 @@
         },
         "pieType": "pie",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": true
         },
@@ -401,7 +411,9 @@
         },
         "pieType": "pie",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": true
         },
@@ -472,7 +484,9 @@
         },
         "pieType": "pie",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": true
         },
@@ -816,7 +830,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -872,7 +888,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -923,7 +941,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -989,7 +1009,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1086,7 +1108,9 @@
         },
         "pieType": "donut",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": true
         },
@@ -1146,7 +1170,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1197,7 +1223,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1248,7 +1276,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1299,7 +1329,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -1357,11 +1389,908 @@
       ],
       "title": "Review Body (Markdown)",
       "type": "marcusolsson-dynamictext-panel"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "id": 20,
+      "title": "AI Prediction vs CI Reality",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 32,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "### How to read this section\n\nThis section correlates AI code review risk assessments with OpenShift CI (Prow) presubmit test results. A PR is considered \"CI failed\" if any non-flaky test case failed on its presubmit runs. Infrastructure failures and flaky tests (tests that also fail on periodic/push runs) are excluded.\n\n**Important:** This shows *correlation*, not causation. CI test failures on a PR may not be directly caused by the PR's code change \u2014 presubmit jobs run broad integration/e2e tests that exercise the entire platform. The metrics are most useful as *trend signals* over time: improving precision/recall suggests AI tools are becoming better predictors of problematic changes.\n\nOnly PRs that have **both** an AI review and OCP CI job results are included. Repos without OCP CI jobs or without AI review bots are excluded.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.0.0",
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": "mysql",
+      "type": "stat",
+      "title": "True Positives (TP)",
+      "description": "AI flagged risky AND CI tests failed \u2014 correct predictions",
+      "id": 21,
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 67
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "mysql",
+          "format": "table",
+          "refId": "A",
+          "rawSql": "WITH flaky_tests AS (SELECT DISTINCT tc.name, j.repository FROM ci_test_cases tc JOIN ci_test_jobs j ON tc.connection_id = j.connection_id AND tc.job_id = j.job_id WHERE tc.status = 'failed' AND j.trigger_type IN ('periodic', 'push') AND j.finished_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)), pr_ci AS (SELECT j.pull_request_number, j.repository, MAX(CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN 1 ELSE 0 END) AS ci_failed FROM ci_test_jobs j JOIN ci_test_cases tc ON j.connection_id = tc.connection_id AND j.job_id = tc.job_id LEFT JOIN flaky_tests ft ON tc.name = ft.name AND j.repository = ft.repository WHERE j.trigger_type = 'pull_request' AND j.pull_request_number IS NOT NULL AND $__timeFilter(j.finished_at) GROUP BY j.pull_request_number, j.repository), pr_review AS (SELECT pr.pull_request_key, r.name AS repo_name, MAX(CASE WHEN ar.risk_level IN ('high','critical') OR ar.risk_score >= 70 THEN 1 ELSE 0 END) AS flagged_risky FROM _tool_aireview_reviews ar JOIN pull_requests pr ON ar.pull_request_id = pr.id JOIN repos r ON ar.repo_id = r.id WHERE ar.repo_id IN (${repo_id:sqlstring}) AND ar.ai_tool IN (${ai_tool:sqlstring}) AND $__timeFilter(ar.created_date) GROUP BY pr.pull_request_key, r.name) SELECT COUNT(*) AS true_positives FROM pr_review rv INNER JOIN pr_ci ci ON rv.pull_request_key = ci.pull_request_number AND SUBSTRING_INDEX(rv.repo_name, '/', -1) = ci.repository WHERE rv.flagged_risky = 1 AND ci.ci_failed = 1"
+        }
+      ]
+    },
+    {
+      "datasource": "mysql",
+      "type": "stat",
+      "title": "False Positives (FP)",
+      "description": "AI flagged risky BUT CI tests passed \u2014 false alarms",
+      "id": 22,
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 67
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "mysql",
+          "format": "table",
+          "refId": "A",
+          "rawSql": "WITH flaky_tests AS (SELECT DISTINCT tc.name, j.repository FROM ci_test_cases tc JOIN ci_test_jobs j ON tc.connection_id = j.connection_id AND tc.job_id = j.job_id WHERE tc.status = 'failed' AND j.trigger_type IN ('periodic', 'push') AND j.finished_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)), pr_ci AS (SELECT j.pull_request_number, j.repository, MAX(CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN 1 ELSE 0 END) AS ci_failed FROM ci_test_jobs j JOIN ci_test_cases tc ON j.connection_id = tc.connection_id AND j.job_id = tc.job_id LEFT JOIN flaky_tests ft ON tc.name = ft.name AND j.repository = ft.repository WHERE j.trigger_type = 'pull_request' AND j.pull_request_number IS NOT NULL AND $__timeFilter(j.finished_at) GROUP BY j.pull_request_number, j.repository), pr_review AS (SELECT pr.pull_request_key, r.name AS repo_name, MAX(CASE WHEN ar.risk_level IN ('high','critical') OR ar.risk_score >= 70 THEN 1 ELSE 0 END) AS flagged_risky FROM _tool_aireview_reviews ar JOIN pull_requests pr ON ar.pull_request_id = pr.id JOIN repos r ON ar.repo_id = r.id WHERE ar.repo_id IN (${repo_id:sqlstring}) AND ar.ai_tool IN (${ai_tool:sqlstring}) AND $__timeFilter(ar.created_date) GROUP BY pr.pull_request_key, r.name) SELECT COUNT(*) AS false_positives FROM pr_review rv INNER JOIN pr_ci ci ON rv.pull_request_key = ci.pull_request_number AND SUBSTRING_INDEX(rv.repo_name, '/', -1) = ci.repository WHERE rv.flagged_risky = 1 AND ci.ci_failed = 0"
+        }
+      ]
+    },
+    {
+      "datasource": "mysql",
+      "type": "stat",
+      "title": "False Negatives (FN)",
+      "description": "AI did NOT flag risky BUT CI tests failed \u2014 missed failures",
+      "id": 23,
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 67
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "mysql",
+          "format": "table",
+          "refId": "A",
+          "rawSql": "WITH flaky_tests AS (SELECT DISTINCT tc.name, j.repository FROM ci_test_cases tc JOIN ci_test_jobs j ON tc.connection_id = j.connection_id AND tc.job_id = j.job_id WHERE tc.status = 'failed' AND j.trigger_type IN ('periodic', 'push') AND j.finished_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)), pr_ci AS (SELECT j.pull_request_number, j.repository, MAX(CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN 1 ELSE 0 END) AS ci_failed FROM ci_test_jobs j JOIN ci_test_cases tc ON j.connection_id = tc.connection_id AND j.job_id = tc.job_id LEFT JOIN flaky_tests ft ON tc.name = ft.name AND j.repository = ft.repository WHERE j.trigger_type = 'pull_request' AND j.pull_request_number IS NOT NULL AND $__timeFilter(j.finished_at) GROUP BY j.pull_request_number, j.repository), pr_review AS (SELECT pr.pull_request_key, r.name AS repo_name, MAX(CASE WHEN ar.risk_level IN ('high','critical') OR ar.risk_score >= 70 THEN 1 ELSE 0 END) AS flagged_risky FROM _tool_aireview_reviews ar JOIN pull_requests pr ON ar.pull_request_id = pr.id JOIN repos r ON ar.repo_id = r.id WHERE ar.repo_id IN (${repo_id:sqlstring}) AND ar.ai_tool IN (${ai_tool:sqlstring}) AND $__timeFilter(ar.created_date) GROUP BY pr.pull_request_key, r.name) SELECT COUNT(*) AS false_negatives FROM pr_review rv INNER JOIN pr_ci ci ON rv.pull_request_key = ci.pull_request_number AND SUBSTRING_INDEX(rv.repo_name, '/', -1) = ci.repository WHERE rv.flagged_risky = 0 AND ci.ci_failed = 1"
+        }
+      ]
+    },
+    {
+      "datasource": "mysql",
+      "type": "stat",
+      "title": "True Negatives (TN)",
+      "description": "AI did NOT flag risky AND CI tests passed \u2014 expected behavior",
+      "id": 24,
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 67
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "mysql",
+          "format": "table",
+          "refId": "A",
+          "rawSql": "WITH flaky_tests AS (SELECT DISTINCT tc.name, j.repository FROM ci_test_cases tc JOIN ci_test_jobs j ON tc.connection_id = j.connection_id AND tc.job_id = j.job_id WHERE tc.status = 'failed' AND j.trigger_type IN ('periodic', 'push') AND j.finished_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)), pr_ci AS (SELECT j.pull_request_number, j.repository, MAX(CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN 1 ELSE 0 END) AS ci_failed FROM ci_test_jobs j JOIN ci_test_cases tc ON j.connection_id = tc.connection_id AND j.job_id = tc.job_id LEFT JOIN flaky_tests ft ON tc.name = ft.name AND j.repository = ft.repository WHERE j.trigger_type = 'pull_request' AND j.pull_request_number IS NOT NULL AND $__timeFilter(j.finished_at) GROUP BY j.pull_request_number, j.repository), pr_review AS (SELECT pr.pull_request_key, r.name AS repo_name, MAX(CASE WHEN ar.risk_level IN ('high','critical') OR ar.risk_score >= 70 THEN 1 ELSE 0 END) AS flagged_risky FROM _tool_aireview_reviews ar JOIN pull_requests pr ON ar.pull_request_id = pr.id JOIN repos r ON ar.repo_id = r.id WHERE ar.repo_id IN (${repo_id:sqlstring}) AND ar.ai_tool IN (${ai_tool:sqlstring}) AND $__timeFilter(ar.created_date) GROUP BY pr.pull_request_key, r.name) SELECT COUNT(*) AS true_negatives FROM pr_review rv INNER JOIN pr_ci ci ON rv.pull_request_key = ci.pull_request_number AND SUBSTRING_INDEX(rv.repo_name, '/', -1) = ci.repository WHERE rv.flagged_risky = 0 AND ci.ci_failed = 0"
+        }
+      ]
+    },
+    {
+      "datasource": "mysql",
+      "type": "gauge",
+      "title": "Precision",
+      "description": "TP / (TP + FP) \u2014 How accurate are AI risk flags?",
+      "id": 25,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 71
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 40
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": "mysql",
+          "format": "table",
+          "refId": "A",
+          "rawSql": "WITH flaky_tests AS (SELECT DISTINCT tc.name, j.repository FROM ci_test_cases tc JOIN ci_test_jobs j ON tc.connection_id = j.connection_id AND tc.job_id = j.job_id WHERE tc.status = 'failed' AND j.trigger_type IN ('periodic', 'push') AND j.finished_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)), pr_ci AS (SELECT j.pull_request_number, j.repository, MAX(CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN 1 ELSE 0 END) AS ci_failed FROM ci_test_jobs j JOIN ci_test_cases tc ON j.connection_id = tc.connection_id AND j.job_id = tc.job_id LEFT JOIN flaky_tests ft ON tc.name = ft.name AND j.repository = ft.repository WHERE j.trigger_type = 'pull_request' AND j.pull_request_number IS NOT NULL AND $__timeFilter(j.finished_at) GROUP BY j.pull_request_number, j.repository), pr_review AS (SELECT pr.pull_request_key, r.name AS repo_name, MAX(CASE WHEN ar.risk_level IN ('high','critical') OR ar.risk_score >= 70 THEN 1 ELSE 0 END) AS flagged_risky FROM _tool_aireview_reviews ar JOIN pull_requests pr ON ar.pull_request_id = pr.id JOIN repos r ON ar.repo_id = r.id WHERE ar.repo_id IN (${repo_id:sqlstring}) AND ar.ai_tool IN (${ai_tool:sqlstring}) AND $__timeFilter(ar.created_date) GROUP BY pr.pull_request_key, r.name), counts AS (SELECT SUM(CASE WHEN rv.flagged_risky = 1 AND ci.ci_failed = 1 THEN 1 ELSE 0 END) AS tp, SUM(CASE WHEN rv.flagged_risky = 1 AND ci.ci_failed = 0 THEN 1 ELSE 0 END) AS fp FROM pr_review rv INNER JOIN pr_ci ci ON rv.pull_request_key = ci.pull_request_number AND SUBSTRING_INDEX(rv.repo_name, '/', -1) = ci.repository) SELECT ROUND(tp * 100.0 / NULLIF(tp + fp, 0), 1) AS precision_pct FROM counts"
+        }
+      ]
+    },
+    {
+      "datasource": "mysql",
+      "type": "gauge",
+      "title": "Recall",
+      "description": "TP / (TP + FN) \u2014 How many real failures does AI catch?",
+      "id": 26,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 71
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 40
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": "mysql",
+          "format": "table",
+          "refId": "A",
+          "rawSql": "WITH flaky_tests AS (SELECT DISTINCT tc.name, j.repository FROM ci_test_cases tc JOIN ci_test_jobs j ON tc.connection_id = j.connection_id AND tc.job_id = j.job_id WHERE tc.status = 'failed' AND j.trigger_type IN ('periodic', 'push') AND j.finished_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)), pr_ci AS (SELECT j.pull_request_number, j.repository, MAX(CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN 1 ELSE 0 END) AS ci_failed FROM ci_test_jobs j JOIN ci_test_cases tc ON j.connection_id = tc.connection_id AND j.job_id = tc.job_id LEFT JOIN flaky_tests ft ON tc.name = ft.name AND j.repository = ft.repository WHERE j.trigger_type = 'pull_request' AND j.pull_request_number IS NOT NULL AND $__timeFilter(j.finished_at) GROUP BY j.pull_request_number, j.repository), pr_review AS (SELECT pr.pull_request_key, r.name AS repo_name, MAX(CASE WHEN ar.risk_level IN ('high','critical') OR ar.risk_score >= 70 THEN 1 ELSE 0 END) AS flagged_risky FROM _tool_aireview_reviews ar JOIN pull_requests pr ON ar.pull_request_id = pr.id JOIN repos r ON ar.repo_id = r.id WHERE ar.repo_id IN (${repo_id:sqlstring}) AND ar.ai_tool IN (${ai_tool:sqlstring}) AND $__timeFilter(ar.created_date) GROUP BY pr.pull_request_key, r.name), counts AS (SELECT SUM(CASE WHEN rv.flagged_risky = 1 AND ci.ci_failed = 1 THEN 1 ELSE 0 END) AS tp, SUM(CASE WHEN rv.flagged_risky = 0 AND ci.ci_failed = 1 THEN 1 ELSE 0 END) AS fn FROM pr_review rv INNER JOIN pr_ci ci ON rv.pull_request_key = ci.pull_request_number AND SUBSTRING_INDEX(rv.repo_name, '/', -1) = ci.repository) SELECT ROUND(tp * 100.0 / NULLIF(tp + fn, 0), 1) AS recall_pct FROM counts"
+        }
+      ]
+    },
+    {
+      "datasource": "mysql",
+      "type": "gauge",
+      "title": "Accuracy",
+      "description": "(TP + TN) / Total \u2014 Overall prediction correctness",
+      "id": 27,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 71
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 40
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": "mysql",
+          "format": "table",
+          "refId": "A",
+          "rawSql": "WITH flaky_tests AS (SELECT DISTINCT tc.name, j.repository FROM ci_test_cases tc JOIN ci_test_jobs j ON tc.connection_id = j.connection_id AND tc.job_id = j.job_id WHERE tc.status = 'failed' AND j.trigger_type IN ('periodic', 'push') AND j.finished_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)), pr_ci AS (SELECT j.pull_request_number, j.repository, MAX(CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN 1 ELSE 0 END) AS ci_failed FROM ci_test_jobs j JOIN ci_test_cases tc ON j.connection_id = tc.connection_id AND j.job_id = tc.job_id LEFT JOIN flaky_tests ft ON tc.name = ft.name AND j.repository = ft.repository WHERE j.trigger_type = 'pull_request' AND j.pull_request_number IS NOT NULL AND $__timeFilter(j.finished_at) GROUP BY j.pull_request_number, j.repository), pr_review AS (SELECT pr.pull_request_key, r.name AS repo_name, MAX(CASE WHEN ar.risk_level IN ('high','critical') OR ar.risk_score >= 70 THEN 1 ELSE 0 END) AS flagged_risky FROM _tool_aireview_reviews ar JOIN pull_requests pr ON ar.pull_request_id = pr.id JOIN repos r ON ar.repo_id = r.id WHERE ar.repo_id IN (${repo_id:sqlstring}) AND ar.ai_tool IN (${ai_tool:sqlstring}) AND $__timeFilter(ar.created_date) GROUP BY pr.pull_request_key, r.name), counts AS (SELECT SUM(CASE WHEN rv.flagged_risky = 1 AND ci.ci_failed = 1 THEN 1 ELSE 0 END) AS tp, SUM(CASE WHEN rv.flagged_risky = 0 AND ci.ci_failed = 0 THEN 1 ELSE 0 END) AS tn, COUNT(*) AS total FROM pr_review rv INNER JOIN pr_ci ci ON rv.pull_request_key = ci.pull_request_number AND SUBSTRING_INDEX(rv.repo_name, '/', -1) = ci.repository) SELECT ROUND((tp + tn) * 100.0 / NULLIF(total, 0), 1) AS accuracy_pct FROM counts"
+        }
+      ]
+    },
+    {
+      "datasource": "mysql",
+      "type": "table",
+      "title": "True Positives: AI Flagged Risky + CI Failed",
+      "description": "PRs where AI correctly predicted risk \u2014 validated by CI test failures",
+      "id": 28,
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 76
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pr_url"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Open PR",
+                    "url": "${__value.text}"
+                  }
+                ]
+              },
+              {
+                "id": "custom.width",
+                "value": 80
+              },
+              {
+                "id": "displayName",
+                "value": "PR"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pr_title"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto",
+                  "wrapText": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed_jobs"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto",
+                  "wrapText": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "cellHeight": "md",
+        "footer": {
+          "countRows": true,
+          "fields": "",
+          "reducer": [
+            "count"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "last_ci_run"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": "mysql",
+          "format": "table",
+          "refId": "A",
+          "rawSql": "WITH flaky_tests AS (SELECT DISTINCT tc.name, j.repository FROM ci_test_cases tc JOIN ci_test_jobs j ON tc.connection_id = j.connection_id AND tc.job_id = j.job_id WHERE tc.status = 'failed' AND j.trigger_type IN ('periodic', 'push') AND j.finished_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)), pr_ci AS (SELECT j.pull_request_number, j.repository, MAX(CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN 1 ELSE 0 END) AS ci_failed, GROUP_CONCAT(DISTINCT CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN j.job_name END SEPARATOR ', ') AS failed_jobs, MAX(j.finished_at) AS last_ci_run FROM ci_test_jobs j JOIN ci_test_cases tc ON j.connection_id = tc.connection_id AND j.job_id = tc.job_id LEFT JOIN flaky_tests ft ON tc.name = ft.name AND j.repository = ft.repository WHERE j.trigger_type = 'pull_request' AND j.pull_request_number IS NOT NULL AND $__timeFilter(j.finished_at) GROUP BY j.pull_request_number, j.repository) SELECT CONCAT('#', pr.pull_request_key) AS pr_number, r.name AS repository, LEFT(pr.title, 80) AS pr_title, CASE MAX(FIELD(ar.risk_level, 'low', 'medium', 'high', 'critical')) WHEN 1 THEN 'low' WHEN 2 THEN 'medium' WHEN 3 THEN 'high' WHEN 4 THEN 'critical' END AS risk_level, MAX(ar.risk_score) AS risk_score, GROUP_CONCAT(DISTINCT ar.ai_tool SEPARATOR ', ') AS ai_tools, DATE_FORMAT(MAX(ar.created_date), '%Y-%m-%d') AS review_date, ci.failed_jobs, DATE_FORMAT(ci.last_ci_run, '%Y-%m-%d %H:%i') AS last_ci_run, pr.url AS pr_url FROM _tool_aireview_reviews ar JOIN pull_requests pr ON ar.pull_request_id = pr.id JOIN repos r ON ar.repo_id = r.id INNER JOIN pr_ci ci ON pr.pull_request_key = ci.pull_request_number AND SUBSTRING_INDEX(r.name, '/', -1) = ci.repository WHERE (ar.risk_level IN ('high','critical') OR ar.risk_score >= 70) AND ci.ci_failed = 1 AND ar.repo_id IN (${repo_id:sqlstring}) AND ar.ai_tool IN (${ai_tool:sqlstring}) AND $__timeFilter(ar.created_date) GROUP BY pr.pull_request_key, r.name, pr.title, pr.url, ci.failed_jobs, ci.last_ci_run ORDER BY ci.last_ci_run DESC LIMIT 50"
+        }
+      ]
+    },
+    {
+      "datasource": "mysql",
+      "type": "table",
+      "title": "False Negatives: AI Missed + CI Failed",
+      "description": "PRs where AI did NOT flag risk but CI tests failed \u2014 what AI should learn from",
+      "id": 29,
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 86
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pr_url"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Open PR",
+                    "url": "${__value.text}"
+                  }
+                ]
+              },
+              {
+                "id": "custom.width",
+                "value": 80
+              },
+              {
+                "id": "displayName",
+                "value": "PR"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pr_title"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto",
+                  "wrapText": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed_jobs"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto",
+                  "wrapText": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "cellHeight": "md",
+        "footer": {
+          "countRows": true,
+          "fields": "",
+          "reducer": [
+            "count"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "last_ci_run"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": "mysql",
+          "format": "table",
+          "refId": "A",
+          "rawSql": "WITH flaky_tests AS (SELECT DISTINCT tc.name, j.repository FROM ci_test_cases tc JOIN ci_test_jobs j ON tc.connection_id = j.connection_id AND tc.job_id = j.job_id WHERE tc.status = 'failed' AND j.trigger_type IN ('periodic', 'push') AND j.finished_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)), pr_ci AS (SELECT j.pull_request_number, j.repository, MAX(CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN 1 ELSE 0 END) AS ci_failed, GROUP_CONCAT(DISTINCT CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN j.job_name END SEPARATOR ', ') AS failed_jobs, MAX(j.finished_at) AS last_ci_run FROM ci_test_jobs j JOIN ci_test_cases tc ON j.connection_id = tc.connection_id AND j.job_id = tc.job_id LEFT JOIN flaky_tests ft ON tc.name = ft.name AND j.repository = ft.repository WHERE j.trigger_type = 'pull_request' AND j.pull_request_number IS NOT NULL AND $__timeFilter(j.finished_at) GROUP BY j.pull_request_number, j.repository) SELECT pr_number, repository, pr_title, risk_level, risk_score, ai_tools, review_date, failed_jobs, last_ci_run, pr_url FROM (SELECT CONCAT('#', pr.pull_request_key) AS pr_number, r.name AS repository, LEFT(pr.title, 80) AS pr_title, CASE MAX(FIELD(COALESCE(ar.risk_level, ''), 'low', 'medium', 'high', 'critical')) WHEN 1 THEN 'low' WHEN 2 THEN 'medium' WHEN 3 THEN 'high' WHEN 4 THEN 'critical' ELSE 'none' END AS risk_level, MAX(ar.risk_score) AS risk_score, MAX(CASE WHEN ar.risk_level IN ('high','critical') OR ar.risk_score >= 70 THEN 1 ELSE 0 END) AS was_flagged, GROUP_CONCAT(DISTINCT ar.ai_tool SEPARATOR ', ') AS ai_tools, DATE_FORMAT(MAX(ar.created_date), '%Y-%m-%d') AS review_date, ci.failed_jobs, DATE_FORMAT(ci.last_ci_run, '%Y-%m-%d %H:%i') AS last_ci_run, pr.url AS pr_url FROM _tool_aireview_reviews ar JOIN pull_requests pr ON ar.pull_request_id = pr.id JOIN repos r ON ar.repo_id = r.id INNER JOIN pr_ci ci ON pr.pull_request_key = ci.pull_request_number AND SUBSTRING_INDEX(r.name, '/', -1) = ci.repository WHERE ci.ci_failed = 1 AND ar.repo_id IN (${repo_id:sqlstring}) AND ar.ai_tool IN (${ai_tool:sqlstring}) AND $__timeFilter(ar.created_date) GROUP BY pr.pull_request_key, r.name, pr.title, pr.url, ci.failed_jobs, ci.last_ci_run) deduped WHERE was_flagged = 0 ORDER BY last_ci_run DESC LIMIT 50"
+        }
+      ]
+    },
+    {
+      "datasource": "mysql",
+      "type": "timeseries",
+      "title": "Prediction Accuracy Over Time",
+      "description": "Weekly trend of precision, recall, and accuracy",
+      "id": 30,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 96
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "mysql",
+          "format": "time_series",
+          "refId": "A",
+          "rawSql": "WITH flaky_tests AS (SELECT DISTINCT tc.name, j.repository FROM ci_test_cases tc JOIN ci_test_jobs j ON tc.connection_id = j.connection_id AND tc.job_id = j.job_id WHERE tc.status = 'failed' AND j.trigger_type IN ('periodic', 'push') AND j.finished_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)), pr_ci AS (SELECT j.pull_request_number, j.repository, MAX(CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN 1 ELSE 0 END) AS ci_failed, MAX(j.finished_at) AS last_ci_run FROM ci_test_jobs j JOIN ci_test_cases tc ON j.connection_id = tc.connection_id AND j.job_id = tc.job_id LEFT JOIN flaky_tests ft ON tc.name = ft.name AND j.repository = ft.repository WHERE j.trigger_type = 'pull_request' AND j.pull_request_number IS NOT NULL AND $__timeFilter(j.finished_at) GROUP BY j.pull_request_number, j.repository), pr_review AS (SELECT pr.pull_request_key, r.name AS repo_name, MAX(CASE WHEN ar.risk_level IN ('high','critical') OR ar.risk_score >= 70 THEN 1 ELSE 0 END) AS flagged_risky FROM _tool_aireview_reviews ar JOIN pull_requests pr ON ar.pull_request_id = pr.id JOIN repos r ON ar.repo_id = r.id WHERE ar.repo_id IN (${repo_id:sqlstring}) AND ar.ai_tool IN (${ai_tool:sqlstring}) AND $__timeFilter(ar.created_date) GROUP BY pr.pull_request_key, r.name), weekly AS (SELECT DATE(DATE_SUB(ci.last_ci_run, INTERVAL WEEKDAY(ci.last_ci_run) DAY)) AS week_start, SUM(CASE WHEN rv.flagged_risky = 1 AND ci.ci_failed = 1 THEN 1 ELSE 0 END) AS tp, SUM(CASE WHEN rv.flagged_risky = 1 AND ci.ci_failed = 0 THEN 1 ELSE 0 END) AS fp, SUM(CASE WHEN rv.flagged_risky = 0 AND ci.ci_failed = 1 THEN 1 ELSE 0 END) AS fn, SUM(CASE WHEN rv.flagged_risky = 0 AND ci.ci_failed = 0 THEN 1 ELSE 0 END) AS tn, COUNT(*) AS total FROM pr_review rv INNER JOIN pr_ci ci ON rv.pull_request_key = ci.pull_request_number AND SUBSTRING_INDEX(rv.repo_name, '/', -1) = ci.repository WHERE ci.last_ci_run IS NOT NULL GROUP BY week_start) SELECT week_start AS time, ROUND((tp + tn) * 100.0 / NULLIF(total, 0), 1) AS accuracy, ROUND(tp * 100.0 / NULLIF(tp + fp, 0), 1) AS `precision`, ROUND(tp * 100.0 / NULLIF(tp + fn, 0), 1) AS recall FROM weekly ORDER BY week_start"
+        }
+      ]
+    },
+    {
+      "datasource": "mysql",
+      "type": "barchart",
+      "title": "CI Failure Rate by AI Risk Level",
+      "description": "Does higher AI risk correlate with more CI failures? (excluding flaky tests)",
+      "id": 31,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 104
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Failure Rate %",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total_prs"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "barRadius": 0.1,
+        "barWidth": 0.7,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "vertical",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "datasource": "mysql",
+          "format": "table",
+          "refId": "A",
+          "rawSql": "WITH flaky_tests AS (SELECT DISTINCT tc.name, j.repository FROM ci_test_cases tc JOIN ci_test_jobs j ON tc.connection_id = j.connection_id AND tc.job_id = j.job_id WHERE tc.status = 'failed' AND j.trigger_type IN ('periodic', 'push') AND j.finished_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)), pr_ci AS (SELECT j.pull_request_number, j.repository, MAX(CASE WHEN tc.status = 'failed' AND ft.name IS NULL THEN 1 ELSE 0 END) AS ci_failed FROM ci_test_jobs j JOIN ci_test_cases tc ON j.connection_id = tc.connection_id AND j.job_id = tc.job_id LEFT JOIN flaky_tests ft ON tc.name = ft.name AND j.repository = ft.repository WHERE j.trigger_type = 'pull_request' AND j.pull_request_number IS NOT NULL AND $__timeFilter(j.finished_at) GROUP BY j.pull_request_number, j.repository) SELECT risk_level, COUNT(*) AS total_prs, ROUND(SUM(ci_failed) * 100.0 / NULLIF(COUNT(*), 0), 1) AS failure_rate_pct FROM (SELECT pr.pull_request_key, r.name AS repo_name, CASE MAX(FIELD(ar.risk_level, 'low', 'medium', 'high', 'critical')) WHEN 1 THEN 'low' WHEN 2 THEN 'medium' WHEN 3 THEN 'high' WHEN 4 THEN 'critical' END AS risk_level, ci.ci_failed FROM _tool_aireview_reviews ar JOIN pull_requests pr ON ar.pull_request_id = pr.id JOIN repos r ON ar.repo_id = r.id INNER JOIN pr_ci ci ON pr.pull_request_key = ci.pull_request_number AND SUBSTRING_INDEX(r.name, '/', -1) = ci.repository WHERE ar.repo_id IN (${repo_id:sqlstring}) AND ar.ai_tool IN (${ai_tool:sqlstring}) AND ar.risk_level IS NOT NULL AND ar.risk_level != '' AND $__timeFilter(ar.created_date) GROUP BY pr.pull_request_key, r.name, ci.ci_failed) deduped GROUP BY risk_level ORDER BY FIELD(risk_level, 'low', 'medium', 'high', 'critical')"
+        }
+      ]
     }
   ],
   "refresh": "",
   "schemaVersion": 39,
-  "tags": ["ai", "code-review", "aireview"],
+  "tags": [
+    "ai",
+    "code-review",
+    "aireview"
+  ],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
# AI Code Review Analytics: AI Prediction vs CI Reality

## Summary

Add a new section to the AI Code Review Analytics dashboard that correlates CodeRabbit, Qodo AI risk assessments with actual OpenShift CI (Prow) presubmit test results. This enables measurement of the **AI-Predicted Failure Avoidance** metric — validating whether AI code review can be trusted as a quality gatekeeper.

## What was added

### New dashboard section: "AI Prediction vs CI Reality"

13 new panels added to `grafana/dashboards/AIReview.json` (panels 20-32):

**Info panel** — Explains how to interpret the data, including the correlation-vs-causation caveat and filtering methodology.

This section correlates AI code review risk assessments with OpenShift CI (Prow) presubmit test results. A PR is considered "CI failed" if any non-flaky test case failed on its presubmit runs. Infrastructure failures and flaky tests (tests that also fail on periodic/push runs) are excluded.

Important: This shows correlation, not causation. CI test failures on a PR may not be directly caused by the PR's code change — presubmit jobs run broad integration/e2e tests that exercise the entire platform. The metrics are most useful as trend signals over time: improving precision/recall suggests AI tools are becoming better predictors of problematic changes.

Only PRs that have both an AI review and OCP CI job results are included. Repos without OCP CI jobs or without AI review bots are excluded.

**Confusion Matrix (4 stat panels):**
- **True Positives (TP)** — AI flagged risky AND CI tests failed. Correct predictions.
- **False Positives (FP)** — AI flagged risky BUT CI tests passed. False alarms.
- **False Negatives (FN)** — AI did NOT flag risky BUT CI tests failed. Missed failures.
- **True Negatives (TN)** — AI did NOT flag risky AND CI tests passed. Expected behavior.

**Metric Gauges (3 panels):**
- **Precision** — TP / (TP + FP). How accurate are AI risk flags? (>80% = can auto-block PRs)
- **Recall** — TP / (TP + FN). How many real failures does AI catch? (>70% = useful gatekeeper)
- **Accuracy** — (TP + TN) / Total. Overall prediction correctness.

**Actionable Tables (2 panels):**
- **True Positives table** — PRs where AI correctly predicted risk, confirmed by CI failures. Shows PR#, repo, title, highest risk level, max risk score, AI tools used, failed job names, and clickable PR link. Deduplicated per PR.
- **False Negatives table** — PRs where AI missed the risk but CI failed. Shows what AI should learn from. Same columns. Deduplicated per PR, with NULL risk levels handled correctly.

**Trend Analysis (1 panel):**
- **Prediction Accuracy Over Time** — Weekly timeseries with three lines: precision, recall, and accuracy (0-100%). Shows whether AI prediction quality is improving over time.

**Correlation Chart (1 panel):**
- **CI Failure Rate by AI Risk Level** — Bar chart showing failure rate for low/medium/high/critical risk levels. Validates whether higher AI risk scores actually correlate with more CI failures.

## How it works

### Data flow

```
CodeRabbit reviews PR → _tool_aireview_reviews (risk_level, risk_score)
                              ↓ (via pull_request_id)
                        pull_requests (pull_request_key = PR number)
                              ↓ (via PR number + repo name)
OCP CI runs on PR     → ci_test_jobs (pull_request_number, result)
                              ↓
                        ci_test_cases (status = passed/failed/skipped)
```

### Classification logic

A PR is **"flagged risky"** by AI if:
- `risk_level IN ('high', 'critical')` OR `risk_score >= 70`

A PR has a **"CI failure"** if:
- At least one `ci_test_cases.status = 'failed'` exists on its presubmit runs
- Excluding flaky tests and infrastructure failures (see filtering below)

The confusion matrix outcome is then:

| | CI Failed | CI Passed |
|---|---|---|
| **AI Flagged Risky** | TP | FP |
| **AI Not Flagged** | FN | TN |

### Filtering out noise

Two layers of filtering ensure only meaningful test failures are counted:

1. **Infrastructure filter** — Only counts failures that have actual test case failures (`ci_test_cases.status = 'failed'`). Jobs that fail before tests run (cluster provisioning, quota, timeout) are excluded.

2. **Flaky test filter** — Tests that also fail on `periodic` or `push` runs (not triggered by any PR) within a **fixed 30-day trailing window** are excluded. This window is independent of the dashboard time range to ensure consistent flaky detection regardless of the selected time period.

### Deduplication

A single PR can have multiple AI reviews (from different tools, or re-reviews). To prevent inflating the confusion matrix:

- **Stat panels (TP/FP/FN/TN) and gauges** aggregate per PR using `GROUP BY pull_request_key` with `MAX(flagged_risky)` — if ANY review on a PR flagged it as risky, the PR is considered flagged.
- **Table panels** also deduplicate per PR, showing the highest risk level (using ordinal comparison via `FIELD()`, not lexicographic `MAX()`), max risk score, and all AI tools concatenated.
- **Risk level ordering** uses `FIELD(risk_level, 'low', 'medium', 'high', 'critical')` for correct ordinal comparison — string-based `MAX()` would incorrectly rank `'critical' < 'medium'` alphabetically.
- All panels apply `$__timeFilter(ar.created_date)` on the review side to respect the dashboard time range.

### Scope

- Only PRs that have **both** an AI review AND OCP CI presubmit job results are included
- Repos without OCP CI jobs (e.g., podman-desktop) are silently excluded
- Repos without AI review bots are silently excluded
- The `repos.name` (e.g., `openshift/console`) is matched to `ci_test_jobs.repository` (e.g., `console`) using `SUBSTRING_INDEX` to extract the repo name from the full path

## Why it's relevant

### AI-Predicted Failure Avoidance metric

This dashboard section directly supports the AI-Predicted Failure Avoidance initiative:

> **Key Question:** Can I trust AI to block risky changes automatically, or does every AI flag still need human validation?

The decision framework based on the metrics:

| Precision | Recall | Recommended AI Autonomy |
|---|---|---|
| >80% | >70% | Can auto-block risky PRs |
| 60-80% | 50-70% | Flag for mandatory human review |
| <60% | <50% | AI advisory only, no enforcement |

### Correlation, not causation

The dashboard includes an info panel explaining that this shows **correlation** between AI risk assessments and CI test results, not causation. CI presubmit jobs run broad integration/e2e tests that may fail for reasons unrelated to the PR's code change. The metrics are most useful as **trend signals** — improving precision/recall over time suggests AI tools are becoming better predictors.

### Actionable insights

- **True Positives table** validates AI's value — these are real catches
- **False Negatives table** shows what AI missed — teams can investigate patterns and improve AI training
- **CI Failure Rate by Risk Level** chart validates whether the risk scoring model is calibrated correctly
- **Trend chart** enables weekly/monthly review of AI prediction quality

## Files changed

| File | Change |
|------|--------|
| `grafana/dashboards/AIReview.json` | Added 13 panels (1 info + 4 stat + 3 gauge + 2 table + 1 timeseries + 1 barchart + 1 row header) |

## Review passes completed

- Multiple rounds of code review addressing: SQL correctness, deduplication, ordinal risk comparison, time filter consistency, NULL handling, division-by-zero protection
- Security review: all SQL uses `${var:sqlstring}` escaping, no credentials or injection vectors

## Verification

1. Rebuild Grafana: `podman compose -f docker-compose-dev.yml up -d --build grafana`
2. Open the AI Code Review Analytics dashboard
3. Scroll to "AI Prediction vs CI Reality" section
4. Verify info panel explains correlation-vs-causation caveat
5. Verify confusion matrix shows counts (requires repos with both AI reviews and OCP CI jobs)
6. Verify Precision/Recall/Accuracy gauges render with thresholds (0=red, 40=orange, 60=yellow, 80=green)
7. Verify True Positives and False Negatives tables show deduplicated PR details with clickable links
8. Verify trend chart shows weekly data points for precision, recall, accuracy
9. Verify CI Failure Rate by Risk Level bar chart orders levels correctly (low → medium → high → critical)
10. Test variable filtering (Repository, AI Tool)
11. Test time range changes — all panels should update consistently
