### PR TITLE
chore(KFLUXDP-996): add agentready dashboards

### DIFF
--- a/dashboards/Engineering/AgentReady/findings-analysis.json
+++ b/dashboards/Engineering/AgentReady/findings-analysis.json
@@ -1,0 +1,118 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_DEVLAKE",
+      "label": "DevLake",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "mysql",
+      "pluginName": "MySQL"
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "panels": [
+    {
+      "title": "Most Common Failures",
+      "type": "barchart",
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 0 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT\n  f.attribute_name,\n  COUNT(*) AS failure_count\nFROM _tool_agentready_findings f\nWHERE f.status = 'fail'\nGROUP BY f.attribute_id, f.attribute_name\nORDER BY failure_count DESC\nLIMIT 15",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "red", "mode": "fixed" }
+        }
+      }
+    },
+    {
+      "title": "Tier Pass Rates Over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 0 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT\n  DATE(m.assessed_at) AS time,\n  AVG(m.tier1_pass_rate) AS 'Essential',\n  AVG(m.tier2_pass_rate) AS 'Critical',\n  AVG(m.tier3_pass_rate) AS 'Important',\n  AVG(m.tier4_pass_rate) AS 'Advanced'\nFROM _tool_agentready_metrics m\nWHERE $__timeFilter(m.assessed_at)\nGROUP BY DATE(m.assessed_at)\nORDER BY time",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 5
+          }
+        }
+      }
+    },
+    {
+      "title": "Remediation Backlog",
+      "type": "table",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 10 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT\n  f.attribute_name,\n  f.category,\n  f.tier,\n  f.default_weight,\n  COUNT(DISTINCT f.repo_id) AS affected_repos,\n  f.remediation_summary\nFROM _tool_agentready_findings f\nWHERE f.status = 'fail'\nGROUP BY f.attribute_id, f.attribute_name, f.category, f.tier, f.default_weight, f.remediation_summary\nORDER BY f.tier ASC, f.default_weight DESC",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "affected_repos" },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-text" }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "yellow", "value": 3 },
+                    { "color": "red", "value": 5 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["agentready", "devlake"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_DEVLAKE",
+        "type": "datasource",
+        "query": "mysql"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "title": "AgentReady - Findings Analysis",
+  "uid": "agentready-findings-analysis"
+}

--- a/dashboards/Engineering/AgentReady/fleet-overview.json
+++ b/dashboards/Engineering/AgentReady/fleet-overview.json
@@ -1,0 +1,201 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_DEVLAKE",
+      "label": "DevLake",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "mysql",
+      "pluginName": "MySQL"
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "title": "Fleet Stats",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT AVG(a.overall_score) AS 'Avg Score'\nFROM _tool_agentready_assessments a\nINNER JOIN (\n  SELECT repo_id, MAX(assessed_at) as max_assessed\n  FROM _tool_agentready_assessments WHERE id != ''\n  GROUP BY repo_id\n) latest ON a.repo_id = latest.repo_id AND a.assessed_at = latest.max_assessed",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 40 },
+              { "color": "yellow", "value": 60 },
+              { "color": "green", "value": 80 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      }
+    },
+    {
+      "title": "Total Repos Assessed",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT COUNT(DISTINCT repo_id) AS 'Total Repos'\nFROM _tool_agentready_assessments WHERE id != ''",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Certification Distribution",
+      "type": "piechart",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT\n  a.certification_level AS metric,\n  COUNT(*) AS value\nFROM _tool_agentready_assessments a\nINNER JOIN (\n  SELECT repo_id, MAX(assessed_at) as max_assessed\n  FROM _tool_agentready_assessments WHERE id != ''\n  GROUP BY repo_id\n) latest ON a.repo_id = latest.repo_id AND a.assessed_at = latest.max_assessed\nGROUP BY a.certification_level",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "values": true,
+          "calcs": []
+        },
+        "pieType": "donut",
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": ["value", "percent"]
+        }
+      },
+      "fieldConfig": {
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Platinum" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#E5E4E2" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Gold" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#FFD700" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Silver" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#C0C0C0" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Bronze" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#CD7F32" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Needs Improvement" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#FF4444" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "None" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#808080" } }]
+          }
+        ]
+      }
+    },
+    {
+      "title": "Score by Repository",
+      "type": "table",
+      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 4 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT\n  a.repo_name,\n  a.overall_score,\n  a.certification_level,\n  a.attributes_assessed,\n  a.attributes_total,\n  a.assessed_at\nFROM _tool_agentready_assessments a\nINNER JOIN (\n  SELECT repo_id, MAX(assessed_at) as max_assessed\n  FROM _tool_agentready_assessments\n  WHERE id != ''\n  GROUP BY repo_id\n) latest ON a.repo_id = latest.repo_id AND a.assessed_at = latest.max_assessed\nORDER BY a.overall_score DESC",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "overall_score" },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "gauge", "mode": "gradient" }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "red", "value": null },
+                    { "color": "orange", "value": 40 },
+                    { "color": "yellow", "value": 60 },
+                    { "color": "green", "value": 80 }
+                  ]
+                }
+              },
+              { "id": "max", "value": 100 }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "title": "Average Score Over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT\n  DATE(assessed_at) AS time,\n  AVG(overall_score) AS 'Average Score'\nFROM _tool_agentready_assessments\nWHERE id != '' AND $__timeFilter(assessed_at)\nGROUP BY DATE(assessed_at)\nORDER BY time",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto"
+          },
+          "min": 0,
+          "max": 100,
+          "unit": "none"
+        }
+      }
+    }
+  ],
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["agentready", "devlake"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_DEVLAKE",
+        "type": "datasource",
+        "query": "mysql"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "title": "AgentReady - Fleet Overview",
+  "uid": "agentready-fleet-overview"
+}

--- a/dashboards/Engineering/AgentReady/repo-detail.json
+++ b/dashboards/Engineering/AgentReady/repo-detail.json
@@ -1,0 +1,212 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_DEVLAKE",
+      "label": "DevLake",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "mysql",
+      "pluginName": "MySQL"
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "panels": [
+    {
+      "title": "Current Score",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT overall_score AS 'Score'\nFROM _tool_agentready_assessments\nWHERE repo_id = '${repo_id}' AND id != ''\nORDER BY assessed_at DESC LIMIT 1",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 40 },
+              { "color": "yellow", "value": 60 },
+              { "color": "green", "value": 80 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      }
+    },
+    {
+      "title": "Certification Level",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT certification_level AS 'Level'\nFROM _tool_agentready_assessments\nWHERE repo_id = '${repo_id}' AND id != ''\nORDER BY assessed_at DESC LIMIT 1",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "/^Level$/"
+        },
+        "textMode": "value",
+        "colorMode": "background"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "blue" },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "Platinum": { "color": "#E5E4E2", "text": "Platinum" },
+                "Gold": { "color": "#FFD700", "text": "Gold" },
+                "Silver": { "color": "#C0C0C0", "text": "Silver" },
+                "Bronze": { "color": "#CD7F32", "text": "Bronze" },
+                "Needs Improvement": { "color": "#FF4444", "text": "Needs Improvement" },
+                "None": { "color": "#808080", "text": "None" }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "title": "Assessment Metadata",
+      "type": "table",
+      "gridPos": { "h": 4, "w": 12, "x": 12, "y": 0 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT\n  repo_name AS 'Repository',\n  attributes_assessed AS 'Assessed',\n  attributes_total AS 'Total',\n  branch AS 'Branch',\n  ROUND(duration_seconds, 1) AS 'Duration (s)'\nFROM _tool_agentready_assessments\nWHERE repo_id = '${repo_id}' AND id != ''\nORDER BY assessed_at DESC LIMIT 1",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Score History",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT assessed_at AS time, overall_score AS 'Score'\nFROM _tool_agentready_assessments\nWHERE repo_id = '${repo_id}' AND id != '' AND $__timeFilter(assessed_at)\nORDER BY assessed_at",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "always"
+          }
+        }
+      }
+    },
+    {
+      "title": "Findings by Tier",
+      "type": "barchart",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT\n  CASE tier WHEN 1 THEN 'Essential' WHEN 2 THEN 'Critical' WHEN 3 THEN 'Important' WHEN 4 THEN 'Advanced' END AS tier_name,\n  SUM(CASE WHEN status = 'pass' THEN 1 ELSE 0 END) AS 'Pass',\n  SUM(CASE WHEN status = 'fail' THEN 1 ELSE 0 END) AS 'Fail'\nFROM _tool_agentready_findings f\nJOIN _tool_agentready_assessments a ON f.assessment_id = a.id\nWHERE a.repo_id = '${repo_id}'\n  AND a.assessed_at = (SELECT MAX(assessed_at) FROM _tool_agentready_assessments WHERE repo_id = '${repo_id}' AND id != '')\nGROUP BY tier\nORDER BY tier",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "stacking": { "mode": "normal" },
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Pass" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Fail" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          }
+        ]
+      }
+    },
+    {
+      "title": "Finding Details",
+      "type": "table",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 12 },
+      "datasource": "${DS_DEVLAKE}",
+      "targets": [
+        {
+          "rawSql": "SELECT\n  f.attribute_name,\n  f.category,\n  f.tier,\n  f.status,\n  f.score,\n  f.measured_value,\n  f.remediation_summary\nFROM _tool_agentready_findings f\nJOIN _tool_agentready_assessments a ON f.assessment_id = a.id\nWHERE a.repo_id = '${repo_id}'\n  AND a.assessed_at = (SELECT MAX(assessed_at) FROM _tool_agentready_assessments WHERE repo_id = '${repo_id}' AND id != '')\nORDER BY f.tier, f.status DESC",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "status" },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-text" }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  { "type": "value", "options": { "pass": { "color": "green", "text": "PASS" } } },
+                  { "type": "value", "options": { "fail": { "color": "red", "text": "FAIL" } } }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["agentready", "devlake"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_DEVLAKE",
+        "type": "datasource",
+        "query": "mysql"
+      },
+      {
+        "name": "repo_id",
+        "type": "query",
+        "datasource": "${DS_DEVLAKE}",
+        "query": "SELECT COALESCE(repo_name, repo_id) AS __text, repo_id AS __value FROM _tool_agentready_assessments WHERE id != '' GROUP BY repo_id, repo_name ORDER BY repo_name",
+        "refresh": 1,
+        "sort": 0
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "title": "AgentReady - Repository Detail",
+  "uid": "agentready-repo-detail"
+}


### PR DESCRIPTION
Related to the agentready plugin developed in KFLUXDP-985.

Related PR: https://github.com/konflux-ci/devlake/pull/85